### PR TITLE
🔒️ Use PyPI trusted publisher

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # permission for PyPI trusted publishing
+      id-token: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -21,10 +25,5 @@ jobs:
         python-version: '3.8'
         cache: true
 
-    - name: Configure PyPI token
-      run: |
-        pdm config repository.pypi.username "__token__"
-        pdm config repository.pypi.password "${{ secrets.PYPI_TOKEN }}"
-
     - name: Publish to PyPI
-      run: pdm publish -r pypi
+      run: pdm publish


### PR DESCRIPTION
## Change Summary

Reconfigured release pipeline to use PyPI trusted publisher instead of a token.
