### PR TITLE
🐛 Fix Pydantic default argument being set to inspect._empty

### DIFF
--- a/repid/converter.py
+++ b/repid/converter.py
@@ -112,7 +112,7 @@ class PydanticConverter:
             **{
                 p.name: (
                     p.annotation if p.annotation is not inspect.Parameter.empty else Any,
-                    p.default if p.annotation is not inspect.Parameter.empty else Field(),
+                    p.default if p.default is not inspect.Parameter.empty else Field(),
                 )
                 for p in signature.parameters.values()
             },


### PR DESCRIPTION
## Change Summary

Due to a type, Pydantic default argument was being set to inspect._empty

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] ~~Documentation reflects the changes where applicable~~
* [x] My PR is ready to review
