### PR TITLE
:bug: Check that function or method registered is awaitable

### DIFF
--- a/repid/middlewares/middleware.py
+++ b/repid/middlewares/middleware.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from inspect import getfullargspec, getmembers, isfunction, ismethod
+from inspect import getfullargspec, getmembers, iscoroutinefunction, isfunction, ismethod
 from typing import Any, Callable, Coroutine
 
 from repid._asyncify import asyncify
@@ -30,6 +30,14 @@ class Middleware:
         if name not in SUBSCRIBERS_NAMES:
             logger.warning(
                 "Function '{fn_name}' wasn't subscribed, as there is no corresponding signal.",
+                extra=logger_extra,
+            )
+            return
+
+        # Prevent accidental registering of synchronous functions
+        if not iscoroutinefunction(fn):
+            logger.error(
+                "Middleware method: '{fn_name}' not subscribed as it is not awaitable.",
                 extra=logger_extra,
             )
             return

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -188,6 +188,25 @@ async def test_add_subscriber(caplog: pytest.LogCaptureFixture) -> None:
         ),
     )
 
+    # Test that non coroutine function is not added as a subscriber
+    async def bar(a: int, b: int) -> int:
+        return a + b
+
+    middleware.add_subscriber(bar)
+    assert bar.__name__ not in middleware.subscribers
+
+    assert any(
+        (
+            all(
+                (
+                    "ERROR" in x,
+                    "Middleware method: 'bar' not subscribed as it is not awaitable." in x,
+                ),
+            )
+            for x in caplog.text.splitlines()
+        ),
+    )
+
 
 def test_middleware_wrapper() -> None:
     @middleware_wrapper


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss it before creating a PR. -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Minor PR to introduce a check to stop accidental non await-able Middleware registration. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review
