### PR TITLE
🐛 Fix RabbitMQ server-side cancel

### DIFF
--- a/repid/connections/rabbitmq/protocols.py
+++ b/repid/connections/rabbitmq/protocols.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
+    import asyncio
+
+    import aiormq
+
     from repid.data.protocols import RoutingKeyT
 
 
@@ -11,4 +17,22 @@ class QueueNameConstructorT(Protocol):
 
 class DurableMessageDeciderT(Protocol):
     def __call__(self, key: RoutingKeyT) -> bool:
+        ...
+
+
+class RabbitConsumerT(Protocol):
+    @property
+    def server_side_cancel_event(self) -> asyncio.Event:
+        ...
+
+    async def on_new_message(self, message: aiormq.abc.DeliveredMessage) -> None:
+        ...
+
+
+class RabbitConsumerCallbackT(Protocol):
+    async def __call__(self, message: aiormq.abc.DeliveredMessage) -> None:
+        ...
+
+    @property
+    def __self__(self) -> RabbitConsumerT:
         ...

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,14 +12,14 @@ if TYPE_CHECKING:
     from pytest_docker_tools import wrappers
 
 redis_container = container(
-    image="redis:7.0-alpine",
+    image="redis:7.2-alpine",
     ports={"6379/tcp": None},
     command="redis-server --requirepass test",
     scope="session",
 )
 
 rabbitmq_container = container(
-    image="rabbitmq:3.11-alpine",
+    image="rabbitmq:3.12-alpine",
     ports={"5672/tcp": None},
     environment={
         "RABBITMQ_DEFAULT_USER": "user",
@@ -29,7 +29,7 @@ rabbitmq_container = container(
 )
 
 rabbitmq_container_2 = container(
-    image="rabbitmq:3.11-alpine",
+    image="rabbitmq:3.12-alpine",
     ports={"5672/tcp": None},
     environment={
         "RABBITMQ_DEFAULT_USER": "user",

--- a/tests/integration/test_rabbitmq_specific.py
+++ b/tests/integration/test_rabbitmq_specific.py
@@ -1,0 +1,50 @@
+import asyncio
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from repid import Job, Repid
+from repid.connections.rabbitmq import RabbitMessageBroker
+
+if TYPE_CHECKING:
+    from pytest_docker_tools import wrappers
+
+
+async def test_server_side_cancel(
+    rabbitmq_connection: Repid,
+    rabbitmq_container: "wrappers.Container",
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async with rabbitmq_connection.magic(auto_disconnect=True) as conn:
+        message_broker = cast(RabbitMessageBroker, conn.message_broker)
+        await message_broker.queue_declare("default")
+
+        consumer = message_broker.get_consumer("default")
+
+        await consumer.start()
+
+        await asyncio.sleep(0.5)
+
+        consumers = rabbitmq_container.exec_run("rabbitmqctl list_consumers")
+        ctag = consumers.output.decode().split("\n")[2].split("\t")[2]
+
+        await message_broker._channel.basic_cancel(ctag)
+
+        await Job("do_nothing").enqueue()
+
+        r, _, _ = await asyncio.wait_for(consumer.consume(), timeout=5)
+        assert r.topic == "do_nothing"
+
+        assert any(
+            (
+                all(
+                    (
+                        "ERROR" in x,
+                        "RabbitMQ has terminated consumer" in x,
+                    ),
+                )
+                for x in caplog.text.splitlines()
+            ),
+        )
+
+        await consumer.finish()


### PR DESCRIPTION
## Change Summary

aiormq sets `consumer_cancel_notify` capability on RabbitMQ, but doesn't provide a way for Repid to be informed about those cancelations. Therefore, Repid patches aiormq's `Channel.consumers` dictionary to inform Repid's consumer when it gets deleted.

## Related issue number

fix #148 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review
