### PR TITLE
✨ Separate publisher and consumer channels to allow reconnects

### DIFF
--- a/tests/integration/test_default_flow.py
+++ b/tests/integration/test_default_flow.py
@@ -135,7 +135,8 @@ async def test_dead_queue(autoconn: Repid) -> None:
         if type(broker) is RedisMessageBroker:
             assert await broker.conn.llen("q:default:5:dead") == 1
         elif type(broker) is RabbitMessageBroker:
-            msg = await broker._channel.basic_get("default:dead")
+            channel = await broker._channel
+            msg = await channel.basic_get("default:dead")
             assert msg is not None
             assert msg.header.properties.headers is not None
             assert msg.header.properties.headers.get("topic") == "awesome_job"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss it before creating a PR. -->

## Change Summary

- Separated publisher and consumer channels on RabbitMQ broker
- Make them reconnect on failure instead of raising ConnectionError

## Checklist

* [x] ~~Unit tests for the changes exist~~
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] My PR is ready to review
